### PR TITLE
BASW-380: Fix styles of inputs with errors

### DIFF
--- a/scss/civicrm/common/_forms.scss
+++ b/scss/civicrm/common/_forms.scss
@@ -306,9 +306,12 @@ input.error {
 .crm-inline-error {
   &:not(.crm-error-label):not(input):not(textarea):not(select) {
     background: $brand-danger;
+    border-radius: 3px;
     color: $crm-white;
+    padding: 5px;
 
-    a {
+    a,
+    .crm-marker {
       color: $crm-white;
     }
   }

--- a/scss/civicrm/common/_forms.scss
+++ b/scss/civicrm/common/_forms.scss
@@ -304,7 +304,7 @@ input.error {
 
 .crm-error,
 .crm-inline-error {
-  &:not(.crm-error-label) {
+  &:not(.crm-error-label):not(input):not(textarea):not(select) {
     background: $brand-danger;
     color: $crm-white;
 

--- a/scss/civicrm/contact/pages/_contributions.scss
+++ b/scss/civicrm/contact/pages/_contributions.scss
@@ -647,52 +647,6 @@
     }
   }
 
-  input,
-  select,
-  textarea {
-    &.crm-inline-error,
-    &.crm-error,
-    &.error {
-      background: none !important;
-      border: 1px solid $brand-danger;
-      min-height: 30px;
-    }
-  }
-
-  label {
-    &.crm-inline-error,
-    &.crm-error {
-      background: $brand-danger !important;
-      border-radius: 3px;
-      color: $crm-white !important;
-      padding: 5px;
-
-      &.crm-inline-error {
-        margin: 0 4px;
-      }
-
-      span {
-        background: none;
-        color: $crm-white;
-      }
-    }
-  }
-
-  span {
-    &.crm-error {
-      background: $brand-danger !important;
-      border-radius: 3px;
-      color: $crm-white !important;
-      margin: 2px;
-      padding: 5px;
-
-      span {
-        background: none;
-        color: $crm-white;
-      }
-    }
-  }
-
   .form-layout-compressed td.label {
     padding-left: 0 !important;
   }

--- a/scss/civicrm/contact/pages/_memberships.scss
+++ b/scss/civicrm/contact/pages/_memberships.scss
@@ -191,18 +191,6 @@
 }
 
 .CRM_Member_Form_Membership {
-  input,
-  select,
-  textarea {
-    &.crm-inline-error,
-    &.crm-error,
-    &.error {
-      background: none !important;
-      border: 1px solid $brand-danger;
-      min-height: 30px;
-    }
-  }
-
   select,
   #from_email_address {
     line-height: 1.5em;


### PR DESCRIPTION
## Overview

This PR fixes issue with form inputs that have input errors. Actually, this PR fixes a blocker because it becomes impossible to type anything in input fields once an error is spawned because inputs' text color becomes white on white background and thus invisible.

## Before

1) Input height is changed
2) Text inside inputs is white and thus invisible

![1](https://user-images.githubusercontent.com/3973243/51831970-62196080-22eb-11e9-81e6-fd63a34e867d.gif)

## After

You can see the input text, inputs are rendered consistently and error labels look good as well.

![2](https://user-images.githubusercontent.com/3973243/51830179-2e3c3c00-22e7-11e9-8fe7-52bda52b15c9.gif)

## Technical details

### Remove inputs from error styling

None of the styles above are suitable for inputs, so we are excluding inputs from this styling. We also add two styles which are used in extensions to globalise the styling.

```css
.crm-inline-error {
  /* &:not(.crm-error-label) { */
  &:not(.crm-error-label):not(input):not(textarea):not(select) {
    background: $brand-danger; 
    border-radius: 3px; /* Moving this styling from extensions */
    color: $crm-white;
    padding: 5px; /* Moving this styling from extensions */
```

### Style asterisks inside error labels

Asterisks also need to be white.

```css
.crm-inline-error {
  ... {
    a,
    .crm-marker { /* This is asterisk */
      color: $crm-white;
```

### Removing inconsistent styles from extensions

After moving extensions styling to a global styling we can remove any custom code to make things consistent. We remove the code from:

- scss/civicrm/contact/pages/_contributions.scss
- scss/civicrm/contact/pages/_memberships.scss

## Testing

Full BackstopJS set was run and Memberships and Contributions extensions were tested manually.